### PR TITLE
Feature/signin user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ out/
 ### firebase api key ###
 swim-diary-e5c13-firebase-adminsdk-yootp-f748ac72e2.json
 
-### application.yml ###
+# Ignore environment-specific configuration files
 application.yml
+application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.3'
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.4.0-b180830.0359'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
+++ b/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
@@ -38,6 +38,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter{
       HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
+    String requestURI = request.getRequestURI();
+
+    if (requestURI.equals("/signup") || requestURI.equals("/login")) {
+      filterChain.doFilter(request, response);
+      return; // 필터 건너뛰기
+    }
+
     String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
     String token = getAccessToken(authorizationHeader);
 

--- a/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
+++ b/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
@@ -41,7 +41,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter{
     String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
     String token = getAccessToken(authorizationHeader);
 
-    if(tokenProvider.validToken(token)){
+    if (tokenProvider.validToken(token)) {
       Authentication authentication = tokenProvider.getAuthentication(token);
       SecurityContextHolder.getContext().setAuthentication(authentication);
     }
@@ -55,7 +55,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter{
    * @return Bearer 토큰이 있는 경우 토큰 문자열을 반환, 없으면 null 반환
    */
   private String getAccessToken(String authorizationHeader){
-    if(authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+    if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
       return authorizationHeader.substring(TOKEN_PREFIX.length());
     }
     return null;

--- a/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
+++ b/src/main/java/livoi/swimdiary/config/TokenAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package livoi.swimdiary.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import livoi.swimdiary.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 클라이언트의 요청을 처리할 때 JWT 토큰을 확인하여 인증 정보를 설정하는 필터를 설정하기 위한 클래스입니다.
+ * 스프링 시큐리티의 OncePerRequestFilter를 상속받아 매 요청당 한 번씩 실행
+ */
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter{
+
+  private final TokenProvider tokenProvider;
+  private final static String HEADER_AUTHORIZATION = "Authorization";
+  private final static String TOKEN_PREFIX = "Bearer ";
+
+  /**
+   * 클라이언트의 요청에서 Authorization 헤더를 읽어와 JWT 토큰을 확인한 후,
+   * 유효한 토큰일 경우 해당 토큰을 기반으로 사용자 인증 정보를 SecurityContext에 설정합니다.
+   *
+   * @param request 클라이언트의 요청 정보
+   * @param response 서버에서 클라이언트로 보낼 응답 정보
+   * @param filterChain 요청을 처리하는 필터 체인
+   * @throws ServletException 서블릿 예외 발생 시 예외 발생
+   * @throws IOException I/O 처리 중 오류 발생 시 예외 발생
+   */
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+    String token = getAccessToken(authorizationHeader);
+
+    if(tokenProvider.validToken(token)){
+      Authentication authentication = tokenProvider.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * Authorization 헤더에서 Bearer 토큰을 추출합니다.
+   *
+   * @param authorizationHeader 요청 헤더에 포함된 Authorization 값
+   * @return Bearer 토큰이 있는 경우 토큰 문자열을 반환, 없으면 null 반환
+   */
+  private String getAccessToken(String authorizationHeader){
+    if(authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+      return authorizationHeader.substring(TOKEN_PREFIX.length());
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/livoi/swimdiary/config/WebSecurityConfig.java
+++ b/src/main/java/livoi/swimdiary/config/WebSecurityConfig.java
@@ -35,7 +35,6 @@ public class WebSecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz -> authz
             .requestMatchers("/login", "/signup").permitAll()
-            .requestMatchers("/mind-diary", "/mind-diary/").authenticated()
             .anyRequest().authenticated()
         )
         .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/livoi/swimdiary/config/WebSecurityConfig.java
+++ b/src/main/java/livoi/swimdiary/config/WebSecurityConfig.java
@@ -1,0 +1,69 @@
+package livoi.swimdiary.config;
+
+import livoi.swimdiary.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * 스프링 시큐리티를 설정하는 역할을 하는 클래스 입니다.
+ */
+@RequiredArgsConstructor
+@Configuration
+public class WebSecurityConfig {
+
+  private final TokenProvider tokenProvider;
+
+  /**
+   * SecurityFilterChain 을 설정하는 메서드
+   *
+   * @param http Security 설정을 구성하기 위한 객체
+   * @return 설정된 SecurityFilterChain 반환
+   * @throws Exception 필터 체인 설정 중 오류가 발생할 경우 예외 발생
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers("/login", "/signup").permitAll()
+            .requestMatchers("/mind-diary", "/mind-diary/").authenticated()
+            .anyRequest().authenticated()
+        )
+        .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+        .build();
+  }
+
+  /**
+   * AuthenticationManager를 생성해 인증 절차를 처리하는 메서드
+   *
+   * @param authenticationConfiguration 인증 설정을 제공하는 객체
+   * @return 설정된 AuthenticationManager를 반환
+   * @throws Exception 인증 매니저 생성 중 오류 발생시 예외 발생
+   */
+  @Bean
+  public AuthenticationManager authenticationManager(
+      AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    return authenticationConfiguration.getAuthenticationManager();
+  }
+
+  /**
+   * 비밀번호를 인코딩 하는 메서드
+   * 사용자 비밀번호를 암호화 해 저장하고, 로그인 시 저장된 값을 비교합니다.
+   *
+   * @return BCryptPasswordEncoder 객체를 반환
+   */
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+}

--- a/src/main/java/livoi/swimdiary/config/jwt/JwtProperties.java
+++ b/src/main/java/livoi/swimdiary/config/jwt/JwtProperties.java
@@ -1,0 +1,20 @@
+package livoi.swimdiary.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * issuer, secretkey를 property에서 가져와서 사용하기 위한 클래스
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+  private String issuer;
+  private String secretKey;
+
+}

--- a/src/main/java/livoi/swimdiary/config/jwt/TokenProvider.java
+++ b/src/main/java/livoi/swimdiary/config/jwt/TokenProvider.java
@@ -1,0 +1,113 @@
+package livoi.swimdiary.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import javax.crypto.SecretKey;
+import livoi.swimdiary.domain.Users;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT 토큰을 생성하고 검증하기 위한 클래스
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TokenProvider {
+
+  private final JwtProperties jwtProperties;
+  private SecretKey secretKey;
+
+  @PostConstruct
+  protected void init() {
+    // jwtProperties가 주입된 후에 secretKey를 초기화
+    this.secretKey = Keys.hmacShaKeyFor(
+        jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+  }
+
+  public String generateToken(Users users, Duration expiredAt) {
+    Date now = new Date();
+
+    return makeToken(new Date(now.getTime() + expiredAt.toMillis()), users);
+  }
+
+  private String makeToken(Date expiry, Users users) {
+    Date now = new Date();
+
+    return Jwts.builder()
+        .header()
+        .type("JWT")
+        .and()
+        .issuer(jwtProperties.getIssuer())
+        .issuedAt(now)
+        .expiration(expiry)
+        .subject(users.getEmail())
+        .claim("userId", users.getUserId())
+        .signWith(secretKey, Jwts.SIG.HS512) // 명시하지 않으면 HS256 방식으로 암호화
+        .compact();
+  }
+
+  public boolean validToken(String token) {
+    try {
+      Jwts.parser()
+          .verifyWith(secretKey)
+          .build()
+          .parseSignedClaims(token);
+      return true;
+
+    } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+      log.info("잘못된 JWT 서명입니다.");
+    } catch (ExpiredJwtException e) {
+      log.info("만료된 JWT 토큰입니다.");
+    } catch (UnsupportedJwtException e) {
+      log.info("지원되지 않는 JWT 토큰입니다.");
+    } catch (IllegalArgumentException e) {
+      log.info("JWT 토큰이 잘못되었습니다.");
+    }
+    return false;
+  }
+
+  public Authentication getAuthentication(String token) {
+    Claims claims = getClaims(token);
+    Set<SimpleGrantedAuthority> authorities = Collections.singleton(
+        new SimpleGrantedAuthority("ROLE_USER"));
+
+    return new UsernamePasswordAuthenticationToken(
+        new org.springframework.security.core.userdetails.User(claims.getSubject(),
+            "", authorities), token, authorities);
+  }
+
+  public Long getUserId(String token) {
+    Claims claims = getClaims(token);
+    return claims.get("userId", Long.class);
+  }
+
+  /**
+   * 토큰 기반으로 사용자ID를 가지고 오는 메서드
+   *
+   * @param token 토큰을 가지고 와
+   * @return 토큰을 파싱한 결과를 반환합니다
+   */
+  private Claims getClaims(String token) {
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+}

--- a/src/main/java/livoi/swimdiary/controller/DiaryApiController.java
+++ b/src/main/java/livoi/swimdiary/controller/DiaryApiController.java
@@ -1,5 +1,6 @@
 package livoi.swimdiary.controller;
 
+import jakarta.validation.Valid;
 import livoi.swimdiary.domain.Diary;
 import livoi.swimdiary.dto.AddDiaryRequest;
 import livoi.swimdiary.dto.AddDiaryResponseDto;
@@ -7,9 +8,9 @@ import livoi.swimdiary.dto.UpdateDiaryRequest;
 import livoi.swimdiary.dto.UpdateDiaryResponseDto;
 import livoi.swimdiary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class DiaryApiController {
@@ -24,7 +26,7 @@ public class DiaryApiController {
   private final DiaryService diaryService;
 
   @PostMapping("/mind-diary")
-  public ResponseEntity<AddDiaryResponseDto> addDiary(@RequestBody @Validated AddDiaryRequest request){
+  public ResponseEntity<AddDiaryResponseDto> addDiary(@RequestBody @Valid AddDiaryRequest request){
     Diary savedDiary = diaryService.save(request);
     AddDiaryResponseDto responseDto = AddDiaryResponseDto.fromEntity(savedDiary);
 
@@ -34,7 +36,7 @@ public class DiaryApiController {
 
   @PutMapping("/mind-diary/{diaryId}")
   public ResponseEntity<UpdateDiaryResponseDto> updateDiary(@PathVariable long diaryId,
-      @RequestBody @Validated UpdateDiaryRequest request) {
+      @RequestBody @Valid UpdateDiaryRequest request) {
 
     UpdateDiaryResponseDto updatedDiary = diaryService.update(diaryId, request);
 

--- a/src/main/java/livoi/swimdiary/controller/UserApiController.java
+++ b/src/main/java/livoi/swimdiary/controller/UserApiController.java
@@ -1,33 +1,50 @@
 package livoi.swimdiary.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import livoi.swimdiary.domain.Users;
 import livoi.swimdiary.dto.AddUserRequest;
+import livoi.swimdiary.dto.AddUserResponseDto;
+import livoi.swimdiary.dto.LoginUserRequest;
 import livoi.swimdiary.service.UsersService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 사용자를 등록, 로그인하고 삭제하기 위한 API Controller
+ */
 @RequiredArgsConstructor
-@Controller
+@RestController
 public class UserApiController {
 
   private final UsersService usersService;
 
   @PostMapping("/signup")
-  public String signup(AddUserRequest request){
-    usersService.save(request);
-    return "redirect:/login";
+  public ResponseEntity<AddUserResponseDto> signup(@RequestBody @Validated AddUserRequest request){
+    Users savedUsers = usersService.saveUser(request);
+    AddUserResponseDto userResponseDto = AddUserResponseDto.fromEntity(savedUsers);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(userResponseDto);
   }
 
-  @GetMapping("/logout")
-  public String logout(HttpServletRequest request, HttpServletResponse response) {
-    new SecurityContextLogoutHandler().logout(request, response,
-        SecurityContextHolder.getContext().getAuthentication());
-    return "redirect:/login";
+  @PostMapping("/login")
+  public ResponseEntity<String> login(@RequestBody LoginUserRequest loginUserRequest){
+    String token = usersService.signIn(loginUserRequest);
+    return ResponseEntity.ok(token);
+  }
+
+  @DeleteMapping("user/{userId}")
+  public ResponseEntity<Void> deleteUser(@PathVariable long userId) {
+    usersService.deleteUser(userId);
+
+    return ResponseEntity.ok()
+        .build();
   }
 
 }

--- a/src/main/java/livoi/swimdiary/controller/UserApiController.java
+++ b/src/main/java/livoi/swimdiary/controller/UserApiController.java
@@ -1,0 +1,33 @@
+package livoi.swimdiary.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import livoi.swimdiary.dto.AddUserRequest;
+import livoi.swimdiary.service.UsersService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@RequiredArgsConstructor
+@Controller
+public class UserApiController {
+
+  private final UsersService usersService;
+
+  @PostMapping("/signup")
+  public String signup(AddUserRequest request){
+    usersService.save(request);
+    return "redirect:/login";
+  }
+
+  @GetMapping("/logout")
+  public String logout(HttpServletRequest request, HttpServletResponse response) {
+    new SecurityContextLogoutHandler().logout(request, response,
+        SecurityContextHolder.getContext().getAuthentication());
+    return "redirect:/login";
+  }
+
+}

--- a/src/main/java/livoi/swimdiary/controller/UserApiController.java
+++ b/src/main/java/livoi/swimdiary/controller/UserApiController.java
@@ -1,5 +1,6 @@
 package livoi.swimdiary.controller;
 
+import jakarta.validation.Valid;
 import livoi.swimdiary.domain.Users;
 import livoi.swimdiary.dto.AddUserRequest;
 import livoi.swimdiary.dto.AddUserResponseDto;
@@ -8,7 +9,6 @@ import livoi.swimdiary.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +25,7 @@ public class UserApiController {
   private final UsersService usersService;
 
   @PostMapping("/signup")
-  public ResponseEntity<AddUserResponseDto> signup(@RequestBody @Validated AddUserRequest request){
+  public ResponseEntity<AddUserResponseDto> signup(@RequestBody @Valid AddUserRequest request){
     Users savedUsers = usersService.saveUser(request);
     AddUserResponseDto userResponseDto = AddUserResponseDto.fromEntity(savedUsers);
 
@@ -34,8 +34,9 @@ public class UserApiController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<String> login(@RequestBody LoginUserRequest loginUserRequest){
+  public ResponseEntity<String> login(@RequestBody @Valid LoginUserRequest loginUserRequest){
     String token = usersService.signIn(loginUserRequest);
+
     return ResponseEntity.ok(token);
   }
 

--- a/src/main/java/livoi/swimdiary/domain/Users.java
+++ b/src/main/java/livoi/swimdiary/domain/Users.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,7 +43,7 @@ public class Users implements UserDetails {
   private Integer swimRoutine;
 
   @Builder
-  public Users(Long userId, String username, String email, String password, String nickname, Integer swimRoutine, String auth) {
+  public Users(Long userId, String username, String email, String password, String nickname, Integer swimRoutine) {
     this.userId = userId;
     this.username = username;
     this.email = email;
@@ -60,7 +59,7 @@ public class Users implements UserDetails {
 
   @Override
   public String getUsername(){
-    return email;
+    return username;
   }
 
   @Override

--- a/src/main/java/livoi/swimdiary/domain/Users.java
+++ b/src/main/java/livoi/swimdiary/domain/Users.java
@@ -5,17 +5,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
-
+@Table(name = "users")
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Users {
+public class Users implements UserDetails {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,23 +31,59 @@ public class Users {
   @Column(name = "username", nullable = false)
   private String username;
 
-  @Column(name = "email", nullable = false)
+  @Column(name = "email", nullable = false, unique = true)
   private String email;
 
   @Column(name = "password", nullable = false)
   private String password;
 
+  @Column(name = "nickname")
   private String nickname;
 
   @Column(name = "swim_routine")
   private Integer swimRoutine;
 
   @Builder
-  public Users(String username, String email, String password, String nickname) {
+  public Users(String username, String email, String password, String nickname, Integer swimRoutine, String auth) {
     this.username = username;
     this.email = email;
     this.password = password;
     this.nickname = nickname;
+    this.swimRoutine = swimRoutine;
   }
 
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority("users"));
+  }
+
+  @Override
+  public String getUsername(){
+    return email;
+  }
+
+  @Override
+  public String getPassword(){
+    return password;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return UserDetails.super.isAccountNonExpired();
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return UserDetails.super.isAccountNonLocked();
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return UserDetails.super.isCredentialsNonExpired();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return UserDetails.super.isEnabled();
+  }
 }

--- a/src/main/java/livoi/swimdiary/domain/Users.java
+++ b/src/main/java/livoi/swimdiary/domain/Users.java
@@ -44,7 +44,8 @@ public class Users implements UserDetails {
   private Integer swimRoutine;
 
   @Builder
-  public Users(String username, String email, String password, String nickname, Integer swimRoutine, String auth) {
+  public Users(Long userId, String username, String email, String password, String nickname, Integer swimRoutine, String auth) {
+    this.userId = userId;
     this.username = username;
     this.email = email;
     this.password = password;
@@ -69,21 +70,21 @@ public class Users implements UserDetails {
 
   @Override
   public boolean isAccountNonExpired() {
-    return UserDetails.super.isAccountNonExpired();
+    return true;
   }
 
   @Override
   public boolean isAccountNonLocked() {
-    return UserDetails.super.isAccountNonLocked();
+    return true;
   }
 
   @Override
   public boolean isCredentialsNonExpired() {
-    return UserDetails.super.isCredentialsNonExpired();
+    return true;
   }
 
   @Override
   public boolean isEnabled() {
-    return UserDetails.super.isEnabled();
+    return true;
   }
 }

--- a/src/main/java/livoi/swimdiary/dto/AddDiaryRequest.java
+++ b/src/main/java/livoi/swimdiary/dto/AddDiaryRequest.java
@@ -35,7 +35,6 @@ public class AddDiaryRequest {
 
   public Diary toEntity(Users users){
     return Diary.builder()
-        .diaryId(diaryId)
         .users(users)
         .workoutMood(workoutMood)
         .workoutType(workoutType)

--- a/src/main/java/livoi/swimdiary/dto/AddUserRequest.java
+++ b/src/main/java/livoi/swimdiary/dto/AddUserRequest.java
@@ -1,0 +1,25 @@
+package livoi.swimdiary.dto;
+
+import livoi.swimdiary.domain.Users;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 사용자 등록을 위한 DTO
+ * 새로운 사용자를 서버에 등록할때 사용합니다.
+ */
+
+@Builder
+@Getter
+@Setter
+public class AddUserRequest {
+
+  private Long userId;
+  private String username;
+  private String email;
+  private String password;
+  private String nickname;
+  private Integer swimRoutine;
+
+}

--- a/src/main/java/livoi/swimdiary/dto/AddUserRequest.java
+++ b/src/main/java/livoi/swimdiary/dto/AddUserRequest.java
@@ -1,9 +1,12 @@
 package livoi.swimdiary.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import livoi.swimdiary.domain.Users;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 /**
  * 사용자 등록을 위한 DTO
@@ -16,10 +19,23 @@ import lombok.Setter;
 public class AddUserRequest {
 
   private Long userId;
+  @NotNull
   private String username;
+  @NotNull
   private String email;
+  @NotNull
   private String password;
   private String nickname;
+  @Positive
   private Integer swimRoutine;
 
+  public Users toEntity(BCryptPasswordEncoder encoder) {
+    return Users.builder()
+        .username(username)
+        .email(email)
+        .password(encoder.encode(password))
+        .nickname(nickname)
+        .swimRoutine(swimRoutine)
+        .build();
+  }
 }

--- a/src/main/java/livoi/swimdiary/dto/AddUserResponseDto.java
+++ b/src/main/java/livoi/swimdiary/dto/AddUserResponseDto.java
@@ -1,0 +1,32 @@
+package livoi.swimdiary.dto;
+
+import livoi.swimdiary.domain.Users;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 사용자 등록시 응답으로 전달되는 ResponseDto
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class AddUserResponseDto {
+
+  private final Long userId; // DB에서 자동으로 생성되는 값
+  private final String username;
+  private final String email;
+  private final String nickname;
+  private final Integer swimRoutine;
+
+  public static AddUserResponseDto fromEntity(Users users){
+    return AddUserResponseDto.builder()
+        .userId(users.getUserId())
+        .username(users.getUsername())
+        .email(users.getEmail())
+        .nickname(users.getNickname())
+        .swimRoutine(users.getSwimRoutine())
+        .build();
+  }
+
+}

--- a/src/main/java/livoi/swimdiary/dto/LoginUserRequest.java
+++ b/src/main/java/livoi/swimdiary/dto/LoginUserRequest.java
@@ -1,0 +1,16 @@
+package livoi.swimdiary.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class LoginUserRequest {
+
+  @NotNull
+  private String email;
+  @NotNull
+  private String password;
+
+}

--- a/src/main/java/livoi/swimdiary/repository/DiaryRepository.java
+++ b/src/main/java/livoi/swimdiary/repository/DiaryRepository.java
@@ -3,6 +3,10 @@ package livoi.swimdiary.repository;
 import livoi.swimdiary.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 사용자 엔티티 {@link Diary} 에 대한 데이터베이스 상호작용을 처리하는 인터페이스 입니다.
+ */
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
  }

--- a/src/main/java/livoi/swimdiary/repository/UsersRepository.java
+++ b/src/main/java/livoi/swimdiary/repository/UsersRepository.java
@@ -11,9 +11,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
   /**
-   * 이메일로 사용자를 검색합니다.
+   * 전달받은 이메일로 등록된 사용자가 있는지 조회하는 메서드
+   *
    * @param email 사용자의 이메일
    * @return 이메일과 일치하는 사용자가 존재할 경우 Users 객체 반환
    */
   Optional<Users> findByEmail(String email);
+
+  /**
+   * 전달받은 이메일로 등록된 사용자가 있는지 조회하고 boolean으로 결과 값을 주는 메서드
+   *
+   * @param email 사용자의 이메일
+   * @return 사용자 존재여부 boolean 타입으로 반환
+   */
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/livoi/swimdiary/repository/UsersRepository.java
+++ b/src/main/java/livoi/swimdiary/repository/UsersRepository.java
@@ -1,8 +1,19 @@
 package livoi.swimdiary.repository;
 
+import java.util.Optional;
 import livoi.swimdiary.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 사용자 엔티티 {@link Users} 에 대한 데이터베이스 상호작용을 처리하는 인터페이스 입니다.
+ * 이 인터페이스는 {@code JpaRepository}를 확장해 Spring Data Jpa의 기능을 사용합니다.
+ */
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
+  /**
+   * 이메일로 사용자를 검색합니다.
+   * @param email 사용자의 이메일
+   * @return 이메일과 일치하는 사용자가 존재할 경우 Users 객체 반환
+   */
+  Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/livoi/swimdiary/service/UserDetailService.java
+++ b/src/main/java/livoi/swimdiary/service/UserDetailService.java
@@ -1,0 +1,30 @@
+package livoi.swimdiary.service;
+
+import livoi.swimdiary.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 정보를 조회하기 위한 서비스 로직
+ * UserDetailsService 인터페이스를 구현합니다.
+ */
+@RequiredArgsConstructor
+@Service
+public class UserDetailService implements UserDetailsService {
+
+  private final UsersRepository usersRepository;
+
+  /**
+   * 이메일로 사용자를 검색합니다.
+   * @param email 사용자의 이메일
+   * @return userRepository에서 검색한 이메일 반환.
+   * @throws IllegalArgumentException 사용자 이메일 찾을 수 없을 경우 예외 발생
+   */
+  @Override
+  public UserDetails loadUserByUsername(String email){
+    return usersRepository.findByEmail(email)
+        .orElseThrow(() -> new IllegalArgumentException("User email not found" + email));
+  }
+}

--- a/src/main/java/livoi/swimdiary/service/UserDetailService.java
+++ b/src/main/java/livoi/swimdiary/service/UserDetailService.java
@@ -4,14 +4,14 @@ import livoi.swimdiary.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
 /**
  * 사용자 정보를 조회하기 위한 서비스 로직
  * UserDetailsService 인터페이스를 구현합니다.
  */
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class UserDetailService implements UserDetailsService {
 
   private final UsersRepository usersRepository;
@@ -20,11 +20,12 @@ public class UserDetailService implements UserDetailsService {
    * 이메일로 사용자를 검색합니다.
    * @param email 사용자의 이메일
    * @return userRepository에서 검색한 이메일 반환.
-   * @throws IllegalArgumentException 사용자 이메일 찾을 수 없을 경우 예외 발생
+   * @throws UsernameNotFoundException 사용자 이메일 찾을 수 없을 경우 예외 발생
    */
+
   @Override
-  public UserDetails loadUserByUsername(String email){
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     return usersRepository.findByEmail(email)
-        .orElseThrow(() -> new IllegalArgumentException("User email not found" + email));
+        .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
   }
 }

--- a/src/main/java/livoi/swimdiary/service/UsersService.java
+++ b/src/main/java/livoi/swimdiary/service/UsersService.java
@@ -1,0 +1,35 @@
+package livoi.swimdiary.service;
+
+import livoi.swimdiary.domain.Users;
+import livoi.swimdiary.dto.AddUserRequest;
+import livoi.swimdiary.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 기능을 위한 서비스 로직
+ */
+
+@RequiredArgsConstructor
+@Service
+public class UsersService {
+
+  private final UsersRepository usersRepository;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+  /**
+   * 회원정보를 저장하는 서비스 로직입니다.
+   * @param dto 에서 저장할 사용자가 입력한 정보를 가지고 옵니다.
+   * @return 저장된 사용자의 정보를 반환합니다.
+   */
+  public Long save(AddUserRequest dto) {
+    return usersRepository.save(Users.builder()
+        .username(dto.getUsername())
+        .email(dto.getEmail())
+        .password(bCryptPasswordEncoder.encode(dto.getPassword()))
+        .nickname(dto.getNickname())
+        .swimRoutine(dto.getSwimRoutine())
+        .build()).getUserId();
+  }
+}

--- a/src/main/java/livoi/swimdiary/service/UsersService.java
+++ b/src/main/java/livoi/swimdiary/service/UsersService.java
@@ -31,7 +31,7 @@ public class UsersService {
    * @return 등록한 사용자 정보를 반환합니다.
    */
   public Users saveUser(AddUserRequest request) {
-    if (usersRepository.existsByEmail(request.getEmail())){
+    if (usersRepository.existsByEmail(request.getEmail())) {
      throw new IllegalArgumentException("User email already exists.");
    }
 

--- a/src/main/java/livoi/swimdiary/service/UsersService.java
+++ b/src/main/java/livoi/swimdiary/service/UsersService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 public class UsersService {
 
   private final UsersRepository usersRepository;
-  private final UserDetailService userDetailService;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final TokenProvider tokenProvider;
 
@@ -32,15 +31,12 @@ public class UsersService {
    * @return 등록한 사용자 정보를 반환합니다.
    */
   public Users saveUser(AddUserRequest request) {
-    try {
-      userDetailService.loadUserByUsername(request.getEmail());
-      throw new IllegalArgumentException("User with this email already exists");
+    if (usersRepository.existsByEmail(request.getEmail())){
+     throw new IllegalArgumentException("User email already exists.");
+   }
 
-    } catch (UsernameNotFoundException e) {
-
-      Users users = request.toEntity(bCryptPasswordEncoder);
-      return usersRepository.save(users);
-    }
+    Users users = request.toEntity(bCryptPasswordEncoder);
+    return usersRepository.save(users);
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=swimdiary

--- a/src/main/resources/log-back.xml
+++ b/src/main/resources/log-back.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <!--변수값 설정-->
+  <property name="LOGS_PATH" value="./logs"/>
+  <property name="LOGS_LEVEL" value="INFO"/>
+
+  <!--File Appender-->
+  <!--    RollingAppender은 가장 오래된 로그를 지우면서 저장-->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_PATH}/log_file.log</file>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %highlight(%-5level) %logger{35} - %msg%n</pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_PATH}/%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>10MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>60</maxHistory>
+    </rollingPolicy>
+  </appender>
+  <logger name="org.springframework" level="info"/>
+  <logger name="org.hibernate" level="info"/>
+  <root level="${LOGS_LEVEL}">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/src/test/java/livoi/swimdiary/config/jwt/JwtFactory.java
+++ b/src/test/java/livoi/swimdiary/config/jwt/JwtFactory.java
@@ -1,0 +1,63 @@
+package livoi.swimdiary.config.jwt;
+
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtFactory {
+  private JwtProperties jwtProperties;
+  private SecretKey secretKey;
+
+  @PostConstruct
+  protected void init() {
+    // jwtProperties가 주입된 후에 secretKey를 초기화
+
+    if (jwtProperties == null) {
+      throw new IllegalStateException("JwtProperties not injected!");
+    }
+
+    this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private String subject = "test@gmail.com";
+  private Date issuedAt = new Date();
+  private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+  private Map<String, Object> claims = Collections.emptyMap();
+
+  @Builder
+  public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims){
+
+    this.subject = subject != null ? subject : this.subject;
+    this.issuedAt = issuedAt != null? issuedAt : this.issuedAt;
+    this.expiration = expiration != null ? expiration : this.expiration;
+    this.claims = claims != null ? claims : this.claims;
+  }
+
+  public static JwtFactory withDefaultValues(){
+    return JwtFactory.builder().build();
+  }
+
+  public String createToken(JwtProperties jwtProperties){
+    return Jwts.builder()
+        .header()
+          .type("jwt")
+        .and()
+        .issuer(jwtProperties.getIssuer())
+        .subject(subject)
+        .expiration(expiration)
+        .claims(claims)
+        .signWith(secretKey)
+        .compact();
+  }
+}

--- a/src/test/java/livoi/swimdiary/config/jwt/JwtFactory.java
+++ b/src/test/java/livoi/swimdiary/config/jwt/JwtFactory.java
@@ -1,10 +1,8 @@
 package livoi.swimdiary.config.jwt;
 
 
-import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
@@ -13,22 +11,11 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 public class JwtFactory {
-  private JwtProperties jwtProperties;
-  private SecretKey secretKey;
-
-  @PostConstruct
-  protected void init() {
-    // jwtProperties가 주입된 후에 secretKey를 초기화
-
-    if (jwtProperties == null) {
-      throw new IllegalStateException("JwtProperties not injected!");
-    }
-
-    this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
-  }
 
   private String subject = "test@gmail.com";
   private Date issuedAt = new Date();
@@ -36,22 +23,25 @@ public class JwtFactory {
   private Map<String, Object> claims = Collections.emptyMap();
 
   @Builder
-  public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims){
+  public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims) {
 
     this.subject = subject != null ? subject : this.subject;
-    this.issuedAt = issuedAt != null? issuedAt : this.issuedAt;
+    this.issuedAt = issuedAt != null ? issuedAt : this.issuedAt;
     this.expiration = expiration != null ? expiration : this.expiration;
     this.claims = claims != null ? claims : this.claims;
   }
 
-  public static JwtFactory withDefaultValues(){
+  public static JwtFactory withDefaultValues() {
     return JwtFactory.builder().build();
   }
 
-  public String createToken(JwtProperties jwtProperties){
+  public String createToken(JwtProperties jwtProperties) {
+    SecretKey secretKey = Keys.hmacShaKeyFor(
+        jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+
     return Jwts.builder()
         .header()
-          .type("jwt")
+        .type("jwt")
         .and()
         .issuer(jwtProperties.getIssuer())
         .subject(subject)

--- a/src/test/java/livoi/swimdiary/config/jwt/TokenProviderTest.java
+++ b/src/test/java/livoi/swimdiary/config/jwt/TokenProviderTest.java
@@ -1,0 +1,80 @@
+package livoi.swimdiary.config.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import javax.crypto.SecretKey;
+import livoi.swimdiary.domain.Users;
+import livoi.swimdiary.repository.UsersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TokenProviderTest {
+
+  @Autowired
+  private TokenProvider tokenProvider;
+
+  @Autowired
+  private UsersRepository usersRepository;
+
+  @Autowired
+  private JwtProperties jwtProperties;
+
+  private SecretKey secretKey;
+
+  @BeforeEach
+  void setUp() {
+    // jwtProperties가 주입된 후에 secretKey를 초기화
+    secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+  }
+
+  @DisplayName("generateToken() : 사용자 정보와 만료기간을 전달해 토큰을 만들 수 있다.")
+  @Test
+  void generateToken() {
+    //given
+    Users testUser = usersRepository.save(Users.builder()
+        .username("김탁구")
+        .email("testemail@gmail.com")
+        .password("dev1234!@")
+        .nickname("takk")
+        .swimRoutine(2)
+        .build()
+    );
+
+    // when
+    String token = tokenProvider.generateToken(testUser, Duration.ofDays(14));
+
+    // then
+    Long userId = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .get("userId", Long.class);
+
+    assertThat(userId).isEqualTo(testUser.getUserId());
+
+  }
+
+  @DisplayName("validToken() : 토큰 검증시 유효한 토큰일 경우 유효성 검사에 성공한다.")
+  @Test
+  void validToken_validToken() {
+    // given
+    String token = JwtFactory.withDefaultValues().createToken(jwtProperties);
+
+    // when
+    boolean result = tokenProvider.validToken(token);
+
+    // then
+    assertThat(result).isTrue();
+
+  }
+}

--- a/src/test/java/livoi/swimdiary/config/jwt/TokenProviderTest.java
+++ b/src/test/java/livoi/swimdiary/config/jwt/TokenProviderTest.java
@@ -7,15 +7,19 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Date;
 import javax.crypto.SecretKey;
 import livoi.swimdiary.domain.Users;
 import livoi.swimdiary.repository.UsersRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
 
+@Slf4j
 @SpringBootTest
 class TokenProviderTest {
 
@@ -75,6 +79,22 @@ class TokenProviderTest {
 
     // then
     assertThat(result).isTrue();
+  }
 
+  @DisplayName("validToken : 만료된 토큰으로 토큰 검증 시 유효성 검사에 실패한다.")
+  @Test
+  void validToken_invalidToken() {
+    //given
+    String token = JwtFactory.builder()
+        .expiration(
+            new Date(new Date().getTime() - Duration.ofDays(7).toMillis())) // 유효한 토큰은 현재 + 14
+        .build()
+        .createToken(jwtProperties);
+
+    //when
+    boolean result = tokenProvider.validToken(token);
+
+    //then
+    assertThat(result).isFalse();
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 사용자 등록 기능 개발 
- 사용자 로그인 기능 개발

**이슈**
- 사용자 로그인 후 감정일기 등록 시도시 403 에러가 발생해 filterChain에 .authenticated() 일때 mind-diary를 허용해줬습니다.
- 사용자 등록시 return 값 중 username 항목에 email이 들어가고 있는데 DB에는 정상적으로 반영되고 있어 확인해보니 Entity에서 getUsername 일때 email을 return 하고 있어 usename을 return 하도록 수정했습니다. 이후 signup api 호출시 username 항목에 입력값 정상적으로 반영되는 것 확인 했습니다.  ba012a2a

**질문/ 요청**
- 사용자 삭제기능을 제외한 사용자 등록과 로그인 기능 위주로 리뷰요청 드립니다!
- 사용자 로그인시 토큰 인증을 할 때 토큰은 정상적으로 발급되고, 시그니처도 유효한데도 `validToken` 메서드가 `IllegalArgumentException` 예외가 발생하고 있어 발생 원인을 찾고 있는 중입니다. 토큰 자체에는 이상이 없는데 왜 발생 하는지 찾지 못해 방향이라도 알 수 있을지 문의드립니다 ! (관련 커밋: a84f7a71)
- `validToken_validToken()` 테스트 코드 실행시 secretkey 값이 null 이라는 응답을 받았는데, postman에서 테스트 했을때는 정상적으로 발급 되고 있어서 테스트 위한 jwtFactory의 문제일지 아니면 환경적인 요인일지 아직 해결을 못해 질문 드립니다. (관련 커밋 : ad69dc75)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
사용자 등록, 사용자 로그인, 로그인한 사용자의 감정 일기 등록, 수정시 헤더에 토큰 추가해 정상적으로 반영되는것 확인 했습니다.
테스트코드는 토큰 발급 부분 까지 확인 했으며, 질문 부분인 토큰 검증 부분에서 fail 해서 현재 원인 파악중입니다.

- [ ] 테스트 코드
- [x] API 테스트 
